### PR TITLE
Update StringObfuscation.cpp

### DIFF
--- a/lib/Transforms/Obfuscation/StringObfuscation.cpp
+++ b/lib/Transforms/Obfuscation/StringObfuscation.cpp
@@ -50,7 +50,7 @@ namespace llvm {
                                 std::string section(gv->getSection());
 
                                 // Let's encode the static ones
-                                if (gv->isConstant() && gv->hasInitializer() && str_idx == 0 && section != "llvm.metadata") {
+                                if (gv->isConstant() && gv->hasInitializer() && isa<ConstantDataSequential>(gv->getInitializer()) && section != "llvm.metadata" && section.find("__objc_methname") == std::string::npos) {
                                         ++GlobalsEncoded;
                                         //errs() << " is constant";
 
@@ -62,7 +62,7 @@ namespace llvm {
                                                                                   (GlobalVariable*) 0,
                                                                                   gv->getThreadLocalMode(),
                                                                                   gv->getType()->getAddressSpace());
-                                        dynGV->copyAttributesFrom(gv);
+                                        // dynGV->copyAttributesFrom(gv);
                                         dynGV->setInitializer(gv->getInitializer());
 
                                         Constant *initializer = gv->getInitializer();


### PR DESCRIPTION
1. 修复第一个字符串名称为@.str导致程序识别不到的bug
2. 修复main函数中char p[] = "xxx"形式的字符串生成的名称为@main.p导致程序识别不到的bug
3. 修改以支持ObjectiveC中NSString的混淆