### PR TITLE
Fill the pool with pseudo-random values.

### DIFF
--- a/lib/Transforms/Obfuscation/CryptoUtils.cpp
+++ b/lib/Transforms/Obfuscation/CryptoUtils.cpp
@@ -558,8 +558,9 @@ void CryptoUtils::prng_seed(const std::string _seed) {
   // AES128 key-schedule
   std::mt19937 gens(seeds);
   this->gen = gens;
-
   seeded = true;
+  // Fill the pool with psuedo-random values
+  populate_pool();
 }
 
 CryptoUtils::~CryptoUtils() {


### PR DESCRIPTION
 Fixes issue when user supply --seed parameter for strings obfuscation. Before the fix  get_uint* methods always return 0 if prng_seed() where called with seed.